### PR TITLE
Create sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,21 @@ pathToZip - path to the zip file
 
 Shows all plugins in the account with the id, name, latest version and last changed.
 
-## plugin:download:resources
+## plugin:download:resources [required:path]
 
-Downloads all store resources from store to the given folder
+Downloads all store resources from store to the given folder.
+
+Path should be the Plugin-Resources-Folder of your plugin. e.g. absolute/path/to/plugin/Resources/store
+
+If folder Store does not exists and you specify it in the param of this command the folder will be created as well.
+
+##### Run plugin:create:config before to set configs and automate download for all available plugins.
+
+
+## plugin:create:config
+
+This will retrieve all information from uploaded plugins and will store them to yaml config files. This
+gives your the possibility to handle several plugins.
 
 # FAQ
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
     "ext-zip": "*",
     "ext-dom": "*",
     "erusev/parsedown": "^1.7",
-    "symfony/dotenv": "^4.2"
+    "symfony/dotenv": "^4.2",
+    "symfony/finder": "^4.2",
+    "symfony/yaml": "^4.2"
   },
   "require-dev": {
     "ext-phar": "*",

--- a/src/Commands/ConfigurePluginsCommand.php
+++ b/src/Commands/ConfigurePluginsCommand.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dwayne.sharp
+ * Date: 04.04.2019
+ * Time: 10:50
+ */
+
+namespace FroshPluginUploader\Commands;
+
+use FroshPluginUploader\Components\SBP\Client;
+use FroshPluginUploader\Components\Util;
+use FroshPluginUploader\Structs\Plugin;
+use FroshPluginUploader\Structs\Config\PluginConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+class ConfigurePluginsCommand extends Command implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    protected function configure()
+    {
+        $this->setName('plugin:create:configs')->setDescription(
+            'Creates config-files for each plugin to handle multiple plugins'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io            = new SymfonyStyle($input, $output);
+        $filesystem    = new Filesystem();
+        $pluginConfigs = Util::getPluginConfigs();
+        $client        = $this->container->get(Client::class);
+        $plugins       = $client->Producer()->getPlugins($client->Producer()->getProducer()->id);
+
+        foreach ($plugins as $plugin) {
+            if (false !== array_search($plugin->name, array_column((array)$pluginConfigs, 'name'))) {
+                $this->updateConfig($plugin, $pluginConfigs[$plugin->id], $io, $filesystem);
+            } else {
+                $this->createConfig($plugin, $io, $filesystem);
+            }
+        }
+    }
+
+    /**
+     * @param Plugin       $plugin
+     * @param SymfonyStyle $io
+     * @param Filesystem   $fs
+     */
+    private function createConfig($plugin, $io, $fs)
+    {
+        $pluginConfig             = new PluginConfig();
+        $pluginConfig->id         = $plugin->id;
+        $pluginConfig->name       = $plugin->name;
+        $pluginConfig->version    = $plugin->latestBinary->version;
+        $pluginConfig->status     = $plugin->activationStatus->description;
+        $pluginConfig->lastChange = $plugin->lastChange;
+
+        $this->setPluginPath($pluginConfig, $io, $fs);
+
+        $this->saveYaml($pluginConfig, $fs);
+        $io->success("File {$plugin->name}.yaml has been created!");
+    }
+
+    /**
+     * @param Plugin       $plugin
+     * @param PluginConfig $pluginConfig
+     * @param SymfonyStyle $io
+     * @param Filesystem   $fs
+     */
+    private function updateConfig($plugin, $pluginConfig, $io, $fs)
+    {
+        if (!isset($pluginConfig->version) || $pluginConfig->version !== $plugin->latestBinary->version) {
+            $pluginConfig->version = $plugin->latestBinary->version;
+            $io->success('Version was updated.');
+        }
+
+        if (!isset($pluginConfig->lastChange) || $pluginConfig->lastChange !== $plugin->lastChange) {
+            $pluginConfig->lastChange = $plugin->lastChange;
+            $io->success('Last change was updated.');
+        }
+
+        if (!isset($pluginConfig->status) || $pluginConfig->status !== $plugin->activationStatus->description) {
+            $pluginConfig->status = $plugin->activationStatus->description;
+            $io->success('Status was updated.');
+        }
+
+        $this->setPluginPath($pluginConfig, $io, $fs);
+
+        $this->saveYaml($pluginConfig, $fs);
+        $io->success("File {$pluginConfig->name}.yaml has been updated!");
+    }
+
+    /**
+     * @param PluginConfig $pluginConfig
+     * @param Filesystem   $fs
+     */
+    private function saveYaml($pluginConfig, $fs){
+        $fs->dumpFile(Util::$configDirectory . $pluginConfig->name . '.yaml', Yaml::dump((array)$pluginConfig));
+    }
+
+    /**
+     * @param PluginConfig $pluginConfig
+     * @param SymfonyStyle $io
+     * @param Filesystem   $fs
+     */
+    private function setPluginPath($pluginConfig, $io, $fs)
+    {
+        if (!isset($pluginConfig->path) || empty($pluginConfig->path)) {
+            $pluginPath = $io->ask(
+                "Please enter absolute path to folder that contains {$pluginConfig->name}-Folder: ",
+                dirname(__DIR__)
+            );
+
+            if ($fs->exists(realpath($pluginPath) . '/' . $pluginConfig->name)) {
+                $pluginConfig->path = $pluginPath;
+                $io->success("Path was set. Plugin was found!");
+            } else {
+                $io->error(
+                    "Path does not exists or no Plugin with name {$pluginConfig->name} were found. Path set to: null. Re-Run command."
+                );
+            }
+        }
+    }
+}

--- a/src/Commands/DownloadPluginResourcesCommand.php
+++ b/src/Commands/DownloadPluginResourcesCommand.php
@@ -2,9 +2,9 @@
 
 namespace FroshPluginUploader\Commands;
 
-use FroshPluginUploader\Components\PluginUpdater;
 use FroshPluginUploader\Components\ResourcesDownloader;
 use FroshPluginUploader\Components\Util;
+use FroshPluginUploader\Structs\Config\PluginConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,19 +19,34 @@ class DownloadPluginResourcesCommand extends Command implements ContainerAwareIn
 
     protected function configure(): void
     {
-        $this
-            ->setName('plugin:download:resources')
-            ->setDescription('Downloads the resources from account to given folder. Needed for plugin:upload')
-            ->addArgument('path', InputArgument::REQUIRED, 'Path to /Resources/store folder');
+        $this->setName('plugin:download:resources')->setDescription(
+            'Downloads the resources from account to given folder. Needed for plugin:upload'
+        )->addArgument('path', InputArgument::REQUIRED, 'Path to /Resources/store folder');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!Util::getEnv('PLUGIN_ID')) {
-            throw new \RuntimeException('The enviroment variable $PLUGIN_ID is required');
-        }
+        $plugins = Util::getPluginConfigs(true);
 
-        $this->container->get(ResourcesDownloader::class)->download($input->getArgument('path'));
+        if (empty($plugins)) {
+            /* old version - should be removed later and path should be optional */
+            if (!Util::getEnv('PLUGIN_ID')) {
+                throw new \RuntimeException('The enviroment variable $PLUGIN_ID is required');
+            }
+
+            $this->container->get(ResourcesDownloader::class)->download($input->getArgument('path'));
+        } else {
+            /* new version - no path needed anymore */
+            /**
+             * @var PluginConfig $plugin
+             */
+            foreach ($plugins as $plugin) {
+                putenv("PLUGIN_ID=" . $plugin->id);
+                $this->container->get(ResourcesDownloader::class)->download(
+                    $path = $plugin->path . '/' . $plugin->name . '/Resources/store'
+                );
+            }
+        }
 
         $io = new SymfonyStyle($input, $output);
         $io->success('Downloaded store data to given folder');

--- a/src/Components/Util.php
+++ b/src/Components/Util.php
@@ -2,10 +2,17 @@
 
 namespace FroshPluginUploader\Components;
 
+use FroshPluginUploader\Structs\Config\PluginConfig;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+
 class Util
 {
+    public static $configDirectory = "config/plugins/";
+
     /**
-     * @param $name
+     * @param      $name
      * @param bool $default
      *
      * @return array|bool|false|string
@@ -21,10 +28,16 @@ class Util
         return $var;
     }
 
+    /**
+     * @param string|null $prefix
+     *
+     * @return string
+     * @throws \Exception
+     */
     public static function mkTempDir(?string $prefix = null): string
     {
         if ($prefix === null) {
-            $prefix = (string) random_int(PHP_INT_MIN, PHP_INT_MAX);
+            $prefix = (string)random_int(PHP_INT_MIN, PHP_INT_MAX);
         }
 
         $tmpFolder = sys_get_temp_dir() . '/' . uniqid($prefix, true);
@@ -36,10 +49,53 @@ class Util
         return $tmpFolder;
     }
 
+    /**
+     * @param string $tmpFolder
+     *
+     * @return mixed
+     */
     public static function getPluginName(string $tmpFolder)
     {
-        return current(array_filter(scandir($tmpFolder, SCANDIR_SORT_NONE), function ($value) {
-            return $value[0] !== '.';
-        }));
+        return current(
+            array_filter(
+                scandir($tmpFolder, SCANDIR_SORT_NONE),
+                function ($value) {
+                    return $value[0] !== '.';
+                }
+            )
+        );
+    }
+
+    /**
+     * If hasPath is false, all Plugin-configs will be gathered
+     * @param bool $hasPath
+     *
+     * @return array
+     */
+    public static function getPluginConfigs($hasPath = false)
+    {
+        $filesystem = new Filesystem();
+        $filesystem->mkdir(self::$configDirectory);
+
+        $finder = new Finder();
+        $finder->files()->in(self::$configDirectory);
+
+        $plugins = [];
+
+        /**
+         * @var PluginConfig $config ;
+         */
+        foreach ($finder as $file) {
+            $config = (object)Yaml::parseFile(self::$configDirectory . $file->getFilename());
+            if ($hasPath) {
+                if (!empty($config->path)) {
+                    $plugins[$config->id] = $config;
+                }
+            } else {
+                $plugins[$config->id] = $config;
+            }
+        }
+
+        return $plugins;
     }
 }

--- a/src/Resources/services.xml
+++ b/src/Resources/services.xml
@@ -25,6 +25,9 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="FroshPluginUploader\Commands\ConfigurePluginsCommand" class="FroshPluginUploader\Commands\ConfigurePluginsCommand">
+            <tag name="console.command"/>
+        </service>
 
         <service id="FroshPluginUploader\Components\SBP\Client"/>
         <service id="FroshPluginUploader\Components\PluginBinaryUploader"/>

--- a/src/Structs/Config/PluginConfig.php
+++ b/src/Structs/Config/PluginConfig.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dwayne.sharp
+ * Date: 04.04.2019
+ * Time: 12:21
+ */
+
+namespace FroshPluginUploader\Structs\Config;
+
+use FroshPluginUploader\Structs\Struct;
+
+class PluginConfig extends Struct
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $path;
+
+    /**
+     * @var string
+     */
+    public $version;
+
+    /**
+     * @var string
+     */
+    public $lastChange;
+
+    /**
+     * @var string
+     */
+    public $status;
+}


### PR DESCRIPTION
Created a new command do store some information from each owned plugin that its in store. these information are stored in yaml files and can be used to automaticly set env with putenv or may give the user the option to choose when plugin should be uploaded/updated or what ever he likes to do.
This gives the option to handle several plugins at the same time without changing the plugin_id all the time. The plugin-configs can be retrived by utils. Propably this should be out-sourced into an extra file similar to utils. Some static class. 