### PR TITLE
check for major version when collection compatible shop versions

### DIFF
--- a/src/Components/Generation/Shopware5/Plugin.php
+++ b/src/Components/Generation/Shopware5/Plugin.php
@@ -48,4 +48,9 @@ class Plugin implements PluginInterface
     {
         return $this->rootDir;
     }
+
+    public function getCompatibleMajorVersion(): string
+    {
+        return 'Shopware 5';
+    }
 }

--- a/src/Components/Generation/ShopwarePlatform/Plugin.php
+++ b/src/Components/Generation/ShopwarePlatform/Plugin.php
@@ -47,4 +47,9 @@ class Plugin implements PluginInterface
     {
         return $this->rootFolder;
     }
+
+    public function getCompatibleMajorVersion(): string
+    {
+        return 'Shopware 6';
+    }
 }

--- a/src/Components/PluginBinaryUploader.php
+++ b/src/Components/PluginBinaryUploader.php
@@ -36,7 +36,7 @@ class PluginBinaryUploader
         $binary->changelogs[1]->text = $plugin->getReader()->getNewestChangelogEnglish();
         $binary->ionCubeEncrypted = false;
         $binary->licenseCheckRequired = false;
-        $binary->compatibleSoftwareVersions = iterator_to_array($this->client->General()->getCompatibleShopwareVersions($plugin->getReader()->getMinVersion(), $plugin->getReader()->getMaxVersion()), false);
+        $binary->compatibleSoftwareVersions = iterator_to_array($this->client->General()->getCompatibleShopwareVersions($plugin), false);
 
         // Patch the binary changelog and version
         $this->client->Plugins()->updateBinary($binary, $pluginId);

--- a/src/Components/PluginInterface.php
+++ b/src/Components/PluginInterface.php
@@ -15,4 +15,6 @@ interface PluginInterface
     public function getResourcesFolderPath(): string;
 
     public function getRootDir(): string;
+
+    public function getCompatibleMajorVersion(): string;
 }

--- a/src/Components/SBP/Components/General.php
+++ b/src/Components/SBP/Components/General.php
@@ -2,6 +2,8 @@
 
 namespace FroshPluginUploader\Components\SBP\Components;
 
+use FroshPluginUploader\Components\PluginInterface;
+
 class General extends AbstractComponent
 {
     /**
@@ -9,12 +11,19 @@ class General extends AbstractComponent
      */
     private $allData;
 
-    public function getCompatibleShopwareVersions(string $minVersion, ?string $maxVersion): \Generator
+    public function getCompatibleShopwareVersions(PluginInterface $plugin): \Generator
     {
+        $minVersion = $plugin->getReader()->getMinVersion();
+        $maxVersion = $plugin->getReader()->getMaxVersion();
+
         $versions = $this->getData()['softwareVersions'];
 
         foreach ($versions as $version) {
             if (!$version['selectable']) {
+                continue;
+            }
+            
+            if ($version['major'] != $plugin->getCompatibleMajorVersion()) {
                 continue;
             }
             


### PR DESCRIPTION
I was unable to upload Shopware 5 plugins because the uploader would mark them compatible to Shopware 6.0.0-DP1. I've added a additional check in the `getCompatibleShopwareVersions` method that skips versions that are not on the same major version.

This was only tested with Shopware 5 Plugins as I don't have any Shopware 6 plugins yet.