### PR TITLE
removed check for keywords in composer.json

### DIFF
--- a/src/Components/Generation/ShopwarePlatform/PluginReader.php
+++ b/src/Components/Generation/ShopwarePlatform/PluginReader.php
@@ -9,7 +9,6 @@ class PluginReader implements PluginReaderInterface
     private const REQUIRED_KEYS_COMPOSER_JSON = [
         'name',
         'type',
-        'keywords',
         'description',
         'license',
         'version',


### PR DESCRIPTION
Removed the check for the `keywords` attribute in the composer.json as its neither a required field by shopware nor by the composer definition for the json file.

See https://docs.shopware.com/en/shopware-platform-dev-en/internals/plugins/plugin-information and https://getcomposer.org/doc/04-schema.md#keywords