### PR TITLE
Clean branch name

### DIFF
--- a/src/Components/PluginZip.php
+++ b/src/Components/PluginZip.php
@@ -47,7 +47,10 @@ class PluginZip
             $this->exec('rm -rf ' . escapeshellarg($pluginName . '/' . $item));
         }
 
-        $fileName = $pluginName . '-' . $branch . '.zip';
+        // Clean branch name for filename
+        $branchClean = preg_replace('/[^a-z0-9]+/', '-', strtolower($branch));
+
+        $fileName = $pluginName . '-' . $branchClean . '.zip';
         $filePath = $directory . '/' . $pluginName;
 
         $this->exec(sprintf('zip -r %s %s -x *.git*', escapeshellarg($fileName), escapeshellarg($pluginName)));


### PR DESCRIPTION
Using a '/' in a branch name will crash the zip making process.
For example 'release/1.0.0';

Replaces non-alphanumeric characters with a dash.