### PR TITLE
#22: Introduce npm-install option to plugin:zip:dir

### DIFF
--- a/src/Commands/ZipDirPluginCommand.php
+++ b/src/Commands/ZipDirPluginCommand.php
@@ -6,6 +6,7 @@ use FroshPluginUploader\Components\PluginZip;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -18,12 +19,15 @@ class ZipDirPluginCommand extends Command implements ContainerAwareInterface
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $path = realpath($input->getArgument('gitPath'));
+        $doNpmInstall = (bool) $input->getOption('npm-install');
 
         if (!file_exists($path)) {
             throw new \RuntimeException(sprintf('Folder by path %s does not exist', $input->getArgument('gitPath')));
         }
 
-        $zipPath = $this->container->get(PluginZip::class)->zip($path, $input->getArgument('branch'));
+        /** @var PluginZip $pluginZip */
+        $pluginZip = $this->container->get(PluginZip::class);
+        $zipPath = $pluginZip->zip($path, $input->getArgument('branch'), $doNpmInstall);
 
         $io = new SymfonyStyle($input, $output);
 
@@ -36,6 +40,7 @@ class ZipDirPluginCommand extends Command implements ContainerAwareInterface
             ->setName('plugin:zip:dir')
             ->setDescription('Zips the given directory')
             ->addArgument('gitPath', InputArgument::REQUIRED, 'Path to to git directory')
-            ->addArgument('branch', InputArgument::OPTIONAL, 'Branch to checkout. Default newest version');
+            ->addArgument('branch', InputArgument::OPTIONAL, 'Branch to checkout. Default newest version')
+            ->addOption('npm-install', null,InputOption::VALUE_NONE, 'Whether to try to `npm install` any package.json files before packaging');
     }
 }

--- a/src/Components/PluginZip.php
+++ b/src/Components/PluginZip.php
@@ -16,7 +16,13 @@ class PluginZip
         'src/Resources/store',
     ];
 
-    public function zip(string $directory, ?string $branch = null): string
+    /**
+     * @param string $directory     Base directory of the plugin to package
+     * @param string|null $branch   The branch or tag name to package
+     * @param bool $doNpmInstall    Whether to try to `npm install` any package.json files before packaging
+     * @return string               Path to the finished .zip file
+     */
+    public function zip(string $directory, ?string $branch = null, bool $doNpmInstall = false): string
     {
         $currentCwd = getcwd();
         $branch = $this->getCheckoutBranch($directory, $branch);
@@ -30,6 +36,10 @@ class PluginZip
 
         // Extract the git repository there
         $this->exec(sprintf('git archive %s | tar -x -C %s', escapeshellarg($branch), escapeshellarg($pluginName)));
+
+        if ($doNpmInstall) {
+            $this->handleNpmDependencies($directory . '/' . $pluginName);
+        }
 
         $composerJson = $directory . '/' . $pluginName . '/composer.json';
         $composerJsonBackup = $composerJson . '.bak';
@@ -134,5 +144,30 @@ class PluginZip
             $composerJsonPath,
             json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
         );
+    }
+
+    /**
+     * Will try to `npm install` any node projects inside the given directory.
+     * Test and "node_modules" directories are ignored.
+     *
+     * @param string $directory The directory to search for package.json files
+     */
+    private function handleNpmDependencies(string $directory): void
+    {
+        // find package.json files
+        $packageJsonPaths = [];
+        exec('find ' . escapeshellarg($directory) . ' -name package.json', $packageJsonPaths);
+
+        // ignore packages inside a node_modules directory and ignore test directories
+        $packageJsonPaths = array_filter($packageJsonPaths, static function($path) {
+            return strpos($path, '/node_modules/') === false
+                && strpos($path, '/test/') === false;
+        });
+
+        // run npm install for every valid package.json
+        foreach ($packageJsonPaths as $path) {
+            $dir = dirname($path);
+            $this->exec("(cd $dir && npm install)");
+        }
     }
 }


### PR DESCRIPTION
This PR introduces the new option `--npm-install` to the `plugin:zip:dir` command. It will search the plugin for `package.json´ files and try to `npm install` them using the enviroment's npm.

This is useful if a vendor requires javascript dependencies in their plugin and wants to
- not include the dependencies in their version control
- bundle the latest dependency sources with their plugin

I hope this feature is not outside the scope of this project. Let me know what you think!