### PR TITLE
Refactor installing the composer plugin dependencies into own command

### DIFF
--- a/src/Commands/PreparePluginCommand.php
+++ b/src/Commands/PreparePluginCommand.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace FroshPluginUploader\Commands;
+
+use FroshPluginUploader\Components\PluginPrepare;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class PreparePluginCommand extends Command implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = realpath($input->getArgument('path'));
+
+        if (!file_exists($path)) {
+            throw new \RuntimeException(sprintf('Folder by path %s does not exist', $input->getArgument('path')));
+        }
+        $this->container->get(PluginPrepare::class)->prepare($path, (bool) $input->getOption('scope'), $output);
+
+        return 0;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('ext:prepare')
+            ->setAliases(['plugin:install:dependencies'])
+            ->setDescription('Install all composer plugin dependencies')
+            ->addArgument('path', InputArgument::REQUIRED, 'Path to to directory')
+            ->addOption('scope', null, InputOption::VALUE_OPTIONAL, 'Will attempt to scope plugin dependencies into a distinct namespace to avoid conflict. A config file is recommended on plugin level.', false)
+        ;
+    }
+}

--- a/src/Components/PluginPrepare.php
+++ b/src/Components/PluginPrepare.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace FroshPluginUploader\Components;
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PluginPrepare
+{
+    public function prepare(string $directory, bool $scopeDependencies, OutputInterface $output): void
+    {
+        $composerJson = $directory . '/composer.json';
+        $composerJsonBackup = $composerJson . '.bak';
+
+        if (file_exists($composerJson)) {
+            copy($composerJson, $composerJsonBackup);
+            $this->filterShopwareDependencies($composerJson);
+
+            // Install composer dependencies
+            if ($this->needComposerToRun($composerJson)) {
+                $this->exec('composer install --ignore-platform-reqs --no-dev -n -d ' . escapeshellarg($directory));
+
+                // TODO: Maybe refactor this into own service
+                if ($scopeDependencies) {
+                    $io = new SymfonyStyle(new ArgvInput(), $output);
+                    $plugin = PluginFinder::findPluginByRootFolder($directory);
+                    $this->scopeDependencies($io, $plugin, $directory);
+                }
+                $this->exec('composer dump -o -d ' . escapeshellarg($directory));
+            }
+
+            rename($composerJsonBackup, $composerJson);
+        }
+    }
+
+    /**
+     * Remove Shopware base packages from composer.json
+     * so they aren't bundled with the plugin.
+     */
+    private function filterShopwareDependencies(string $composerJsonPath): void
+    {
+        $json = json_decode(file_get_contents($composerJsonPath), true);
+
+        $keys = ['shopware/platform', 'shopware/core', 'shopware/storefront', 'shopware/administration', 'composer/installers'];
+        foreach ($keys as $key) {
+            if (isset($json['require'][$key])) {
+                unset($json['require'][$key]);
+            }
+        }
+
+        // Add these packages as provided by the plugin
+        $json['provide'] = array_combine($keys, array_fill(0, count($keys), '*'));
+
+        file_put_contents(
+            $composerJsonPath,
+            json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+        );
+    }
+
+    private function needComposerToRun(string $composerJsonPath): bool
+    {
+        $json = json_decode(file_get_contents($composerJsonPath), true);
+
+        // Plugin does not require anything
+        if (empty($json['require'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private function scopeDependencies(
+        SymfonyStyle $io,
+        Generation\ShopwarePlatform\Plugin $plugin,
+        string $directory
+    ): void {
+        try {
+            $this->exec('command -v php-scoper');
+        } catch (\RuntimeException $e) {
+            $io->warning('Could not find php-scoper executable in PATH');
+
+            return;
+        }
+        $io->writeln('Scoping plugin dependencies into ' . $plugin->getName() . '\\ namespace.');
+        $this->exec(
+            'php-scoper add-prefix -n -o ' . escapeshellarg($directory)
+            . ' -d ' . escapeshellarg($directory)
+            . ' -p ' . $plugin->getName()
+        );
+        $io->writeln('');
+    }
+
+    private function exec(string $command): void
+    {
+        exec($command, $output, $ret);
+
+        // @codeCoverageIgnoreStart
+        if ($ret !== 0) {
+            throw new \RuntimeException(sprintf('Command "%s" failed with code %d', $command, $ret));
+        }
+        // @codeCoverageIgnoreEnd
+    }
+}

--- a/tests/Components/PluginPrepareTest.php
+++ b/tests/Components/PluginPrepareTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace FroshPluginUploader\Tests\Components;
+
+use FroshPluginUploader\Components\PluginPrepare;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+class PluginPrepareTest extends TestCase
+{
+    public function testZipShopware6Plugin(): void
+    {
+        $service = new PluginPrepare();
+        $service->prepare(dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPlugin', false, new NullOutput());
+        static::assertDirectoryExists(
+            dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPlugin/vendor/symfony/web-link',
+            'Cannot find the required composer dependencies'
+        );
+        exec('rm -rf ' . dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPlugin/vendor');
+        unlink(dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPlugin/composer.lock');
+    }
+}

--- a/tests/Components/PluginZipTest.php
+++ b/tests/Components/PluginZipTest.php
@@ -2,6 +2,7 @@
 
 namespace FroshPluginUploader\Tests\Components;
 
+use FroshPluginUploader\Components\PluginPrepare;
 use FroshPluginUploader\Components\PluginZip;
 use FroshPluginUploader\Components\ZipStrategy\GitStrategy;
 use FroshPluginUploader\Components\ZipStrategy\PlainStrategy;
@@ -10,9 +11,19 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class PluginZipTest extends TestCase
 {
+    /**
+     * @var PluginPrepare
+     */
+    private $pluginPrepare;
+
+    protected function setUp(): void
+    {
+        $this->pluginPrepare = new PluginPrepare();
+    }
+
     public function testZipShopware6Plugin(): void
     {
-        $service = new PluginZip(new PlainStrategy());
+        $service = new PluginZip(new PlainStrategy(), $this->pluginPrepare);
         $service->zip(dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPlugin', false, new NullOutput());
         static::assertFileExists(getcwd() . '/ShopwarePlatformPlugin.zip');
         unlink(getcwd() . '/ShopwarePlatformPlugin.zip');
@@ -20,7 +31,7 @@ class PluginZipTest extends TestCase
 
     public function testZipShopware6PluginWithoutOtherDeps(): void
     {
-        $service = new PluginZip(new PlainStrategy());
+        $service = new PluginZip(new PlainStrategy(), $this->pluginPrepare);
         $service->zip(dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPluginComposer', false, new NullOutput());
         static::assertFileExists(getcwd() . '/ShopwarePlatformPlugin.zip');
         unlink(getcwd() . '/ShopwarePlatformPlugin.zip');
@@ -28,7 +39,7 @@ class PluginZipTest extends TestCase
 
     public function testGit(): void
     {
-        $service = new PluginZip(new GitStrategy(null));
+        $service = new PluginZip(new GitStrategy(null), $this->pluginPrepare);
         $path = dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPluginComposer';
 
         exec('cd ' . $path . '; git init; git add .');
@@ -45,7 +56,7 @@ class PluginZipTest extends TestCase
 
     public function testScooping(): void
     {
-        $service = new PluginZip(new PlainStrategy());
+        $service = new PluginZip(new PlainStrategy(), $this->pluginPrepare);
         $service->zip(dirname(__DIR__) . '/fixtures/plugins/ShopwarePlatformPlugin', true, new NullOutput());
         static::assertFileExists(getcwd() . '/ShopwarePlatformPlugin.zip');
         unlink(getcwd() . '/ShopwarePlatformPlugin.zip');


### PR DESCRIPTION
Currently one needs to use two `composer.json` files, if one would like to put a plugin into the Shopware store, see for example #92 or https://laenen.me/posts/github-actions-shopware-plugin-zip/#composer-troubles

This PR extracts the installation of the composer dependencies into a different service and exposes this functionality to a custom command.
I am still not sure if I like the name `ext:prepare`, or prefer something like `ext:install-composer-dependencies` or so.