### PR TITLE
Replace `erusev/parsedown` with `league/commonmark`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
     "symfony/finder": "^5.2",
     "guzzlehttp/guzzle": "~7.2",
     "composer/semver": "^3.2",
-    "erusev/parsedown": "^1.7",
     "composer/spdx-licenses": "^1.5",
     "php-parallel-lint/php-var-dump-check": "^0.5.0",
     "knplabs/github-api": "^3.0",
     "http-interop/http-factory-guzzle": "^1.0",
-    "m4tthumphrey/php-gitlab-api": "^11.1"
+    "m4tthumphrey/php-gitlab-api": "^11.1",
+    "league/commonmark": "^1.5"
   },
   "replace": {
     "symfony/polyfill-intl-normalizer": "*",

--- a/tests/Components/PluginUpdaterTest.php
+++ b/tests/Components/PluginUpdaterTest.php
@@ -47,8 +47,8 @@ class PluginUpdaterTest extends TestCase
 
         $updater->sync($plugin, $storePlugin);
 
-        static::assertSame('<p>Test</p>', $storePlugin->infos[0]->description);
-        static::assertSame('<p>Test</p>', $storePlugin->infos[0]->installationManual);
+        static::assertSame('<p>Test</p>', trim($storePlugin->infos[0]->description));
+        static::assertSame('<p>Test</p>', trim($storePlugin->infos[0]->installationManual));
         static::assertSame('Test', $storePlugin->infos[0]->features);
         static::assertSame('Test', $storePlugin->infos[0]->highlights);
     }
@@ -94,8 +94,8 @@ class PluginUpdaterTest extends TestCase
 
         $updater->sync($plugin, $storePlugin);
 
-        static::assertSame('<p>Test</p>', $storePlugin->infos[0]->description);
-        static::assertSame('<p>Test</p>', $storePlugin->infos[0]->installationManual);
+        static::assertSame('<p>Test</p>', trim($storePlugin->infos[0]->description));
+        static::assertSame('<p>Test</p>', trim($storePlugin->infos[0]->installationManual));
         static::assertSame('proprietary', $storePlugin->license['name']);
     }
 


### PR DESCRIPTION
* restrict the set of raw HTML tags (no `<script>`, `<iframe>` et. cetera)
* render external links with `rel=noreferrer noopener` and `target=_blank`

Fixes #115.