### PR TITLE
Do not ignore platform requirements when preparing plugin

### DIFF
--- a/src/Components/PluginPrepare.php
+++ b/src/Components/PluginPrepare.php
@@ -31,7 +31,7 @@ class PluginPrepare
                     unlink($composerLock);
                 }
 
-                $this->exec('composer install --ignore-platform-reqs --no-dev -n -d ' . escapeshellarg($directory));
+                $this->exec('composer install --no-dev -n -d ' . escapeshellarg($directory));
 
                 // TODO: Maybe refactor this into own service
                 if ($scopeDependencies) {


### PR DESCRIPTION
Hi.

I am currently struggling to build my plugin for Shopware 5.5.

A Shopware 5.5 plugin needs to be compatible to PHP ^5.6.4.

I have included other third party dependencies in my project, which transitively depend on different versions of other packages. Now, some packages provide newer revisions which are only compatible with PHP ^7.1.

If calling `composer update` normally, all dependencies are resolved perfectly.

Only, when I am building the zip of my plugin, the uploader calls `composer install --ignore-platform-reqs` which causes packages to be pulled in that require PHP 7+. This fails later with:
```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - symfony/polyfill-php72 v1.22.1 requires php >=7.1 -> your PHP version (5.6.40) overridden by "config.platform.php" version (5.6.40) does not satisfy that requirement.
    - symfony/polyfill-php72 v1.22.1 requires php >=7.1 -> your PHP version (5.6.40) overridden by "config.platform.php" version (5.6.40) does not satisfy that requirement.
```

I tried to workaround the problem by specifying a different `platform.php` in composer config, by using `"symfony/polyfill": "< 1.20"` in `require-dev`, and listing all the packages that were resolved to newer versions needing PHP 7+ in `conflicts` -- but that is tedious.

Thinking about this, I came to the conclusion that using `--ignore-require-dev` is the wrong thing to do in the first place. 

Sure, I just want to package my plugin, not run it. But letting composer resolve dependencies for a platform that is not what I expect it to be is disastrous.